### PR TITLE
fix lab specific MATLAB path

### DIFF
--- a/Stimulus.py
+++ b/Stimulus.py
@@ -253,7 +253,7 @@ class Psychtoolbox(Stimulus):
     def __init__(self, logger, beh):
         import matlab.engine as eng
         self.mat = eng.start_matlab()
-        if os.getenv('LAB')='atlab':
+        if os.getenv('LAB')=='atlab':
             matlabPath=os.path.join('/home',os.getenv('LAB'),'pipeline/setPath.m')
             print('pymouse is using atlab path for PTB')
         else:

--- a/Stimulus.py
+++ b/Stimulus.py
@@ -253,7 +253,12 @@ class Psychtoolbox(Stimulus):
     def __init__(self, logger, beh):
         import matlab.engine as eng
         self.mat = eng.start_matlab()
-        matlabPath=os.path.join('/home',os.getenv('LAB'),'pipeline/setPath.m')
+        if os.getenv('LAB')='atlab':
+            matlabPath=os.path.join('/home',os.getenv('LAB'),'pipeline/setPath.m')
+            print('pymouse is using atlab path for PTB')
+        else:
+            matlabPath=os.path.join('/home',os.getenv('LAB'),'pipeline/setPath_jrlab.m')
+            print('pymouse is using jrlab path for PTB')
         self.mat.run(matlabPath, nargout=0)
 
         # # get datajoint info from environment variables set in startup script


### PR DESCRIPTION
Issue: Needs to run a lab specific matlab file for setting up paths.
solution: Current solution is using 'setpath.m' for user 'atlab' , and using 'setpath_jrlab' for user 'jrlab'. 
'setpath_jrlab.m' with appropriate paths should be added to the [pipeline](https://github.com/cajal/pipeline/tree/master) folder